### PR TITLE
Take key and value for tags/permissions instead of access types/add resource type filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,8 +58,8 @@ jobs:
       BATON_WIZ_CLIENT_SECRET: ${{ secrets.BATON_WIZ_CLIENT_SECRET }}
       BATON_AUTH_URL: 'https://auth.app.wiz.io/oauth/token'
       BATON_ENDPOINT_URL: 'https://api.us83.app.wiz.io/graphql'
-      BATON_RESOURCE_IDS: ${{ secrets.BATON_RESOURCE_IDS }}
-      CONNECTOR_ENTITLEMENT: 'wiz_query_resource_type:53cd6069-47c2-5b03-9412-7373cd69008f:READ'
+      BATON_TAGS: ${{ secrets.BATON_TAGS }}
+      CONNECTOR_ENTITLEMENT: 'wiz_query_resource_type:911d5b8b-1a17-5af0-b1b6-6cca33432c22:s3:*'
       CONNECTOR_PRINCIPAL: 'd1ade4d7-e5c6-5754-9743-766a441d0c83'
     steps:
       - name: Install Go

--- a/cmd/baton-wiz/config.go
+++ b/cmd/baton-wiz/config.go
@@ -12,7 +12,8 @@ var (
 	audience            = field.StringField("audience", field.WithDefaultValue("wiz-api"), field.WithDescription("The audience used to authenticate with Wiz"))
 	resourceIDs         = field.StringSliceField("resource-ids", field.WithDescription("The resource ids to sync"))
 	tags                = field.StringSliceField("tags", field.WithDescription("The tags on resources to sync"))
-	configurationFields = []field.SchemaField{clientIDField, clientSecretField, endpointURL, authURL, audience, resourceIDs, tags}
+	resourceTypes       = field.StringSliceField("wiz-resource-types", field.WithDescription("The wiz resource-types to sync"))
+	configurationFields = []field.SchemaField{clientIDField, clientSecretField, endpointURL, authURL, audience, resourceIDs, tags, resourceTypes}
 )
 
 var configRelations = []field.SchemaFieldRelationship{

--- a/cmd/baton-wiz/main.go
+++ b/cmd/baton-wiz/main.go
@@ -50,15 +50,17 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	audience := v.GetString(audience.FieldName)
 	resourceIDs := v.GetStringSlice(resourceIDs.FieldName)
 	resourceTags := v.GetStringSlice(tags.FieldName)
+	resourceTypes := v.GetStringSlice(resourceTypes.FieldName)
 
 	cb, err := connector.New(ctx, &connector.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		EndpointURL:  endpointURL,
-		AuthURL:      authURL,
-		Audience:     audience,
-		ResourceIDs:  resourceIDs,
-		ResourceTags: resourceTags,
+		ClientID:      clientID,
+		ClientSecret:  clientSecret,
+		EndpointURL:   endpointURL,
+		AuthURL:       authURL,
+		Audience:      audience,
+		ResourceIDs:   resourceIDs,
+		ResourceTags:  resourceTags,
+		ResourceTypes: resourceTypes,
 	})
 	if err != nil {
 		l.Error("wiz-connector: error creating connector", zap.Error(err))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
@@ -81,7 +82,7 @@ fragment EntityEffectiveAccessGraphChartEntity on GraphEntity {
   properties
 }`
 
-const DefaultPageSize = 500
+const DefaultPageSize = 100
 const DefaultEndCursor = "{{endCursor}}"
 
 var grantedEntityTypeFilter = []string{"IDENTITY", "USER_ACCOUNT", "SERVICE_ACCOUNT"}
@@ -287,8 +288,9 @@ func (c *Client) ListResources(ctx context.Context, pToken *pagination.Token) (*
 	if len(c.resourceTags) != 0 {
 		tagKeyValSlice := make([]map[string]interface{}, 0)
 		for _, tag := range c.resourceTags {
+			keyValPair := strings.Split(tag, ":")
 			tagKeyValSlice = append(tagKeyValSlice, map[string]interface{}{
-				"key": "Name", "value": tag,
+				"key": keyValPair[0], "value": keyValPair[1],
 			})
 		}
 		whereClause["tags"] = map[string]interface{}{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -82,7 +82,7 @@ fragment EntityEffectiveAccessGraphChartEntity on GraphEntity {
   properties
 }`
 
-const DefaultPageSize = 100
+const DefaultPageSize = 500
 const DefaultEndCursor = "{{endCursor}}"
 
 var grantedEntityTypeFilter = []string{"IDENTITY", "USER_ACCOUNT", "SERVICE_ACCOUNT"}

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -61,7 +61,7 @@ type ResourcePermissions struct {
 		EntityEffectiveAccessEntries struct {
 			Nodes []struct {
 				GrantedEntity *GrantedEntity `json:"grantedEntity"`
-				AccessTypes   []string       `json:"accessTypes"`
+				Permissions   []string       `json:"permissions"`
 			} `json:"nodes"`
 			PageInfo PageInfo `json:"pageInfo"`
 		} `json:"entityEffectiveAccessEntries"`

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -5,6 +5,11 @@ import (
 	"fmt"
 )
 
+type ResourceTag struct {
+	Key   string
+	Value string
+}
+
 type PageInfo struct {
 	HasNextPage bool   `json:"hasNextPage"`
 	EndCursor   string `json:"endCursor"`

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -64,6 +65,18 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 // New returns a new instance of the connector.
 func New(ctx context.Context, config *Config) (*Connector, error) {
 	l := ctxzap.Extract(ctx)
+
+	resourceTags := make([]*client.ResourceTag, 0)
+	for _, rt := range config.ResourceTags {
+		keyValPair := strings.Split(rt, ":")
+		if len(keyValPair) != 2 {
+			return nil, fmt.Errorf("invalid format for resource tag '%s', format should be 'key:val'", rt)
+		}
+		resourceTags = append(resourceTags, &client.ResourceTag{
+			Key:   keyValPair[0],
+			Value: keyValPair[1],
+		})
+	}
 	cli, err := client.New(ctx,
 		config.ClientID,
 		config.ClientSecret,
@@ -71,7 +84,7 @@ func New(ctx context.Context, config *Config) (*Connector, error) {
 		config.AuthURL,
 		config.EndpointURL,
 		config.ResourceIDs,
-		config.ResourceTags,
+		resourceTags,
 		config.ResourceTypes,
 	)
 	if err != nil {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -14,13 +14,14 @@ import (
 )
 
 type Config struct {
-	ClientID     string
-	ClientSecret string
-	EndpointURL  string
-	AuthURL      string
-	Audience     string
-	ResourceIDs  []string
-	ResourceTags []string
+	ClientID      string
+	ClientSecret  string
+	EndpointURL   string
+	AuthURL       string
+	Audience      string
+	ResourceIDs   []string
+	ResourceTags  []string
+	ResourceTypes []string
 }
 
 type Connector struct {
@@ -63,7 +64,16 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 // New returns a new instance of the connector.
 func New(ctx context.Context, config *Config) (*Connector, error) {
 	l := ctxzap.Extract(ctx)
-	cli, err := client.New(ctx, config.ClientID, config.ClientSecret, config.Audience, config.AuthURL, config.EndpointURL, config.ResourceIDs, config.ResourceTags)
+	cli, err := client.New(ctx,
+		config.ClientID,
+		config.ClientSecret,
+		config.Audience,
+		config.AuthURL,
+		config.EndpointURL,
+		config.ResourceIDs,
+		config.ResourceTags,
+		config.ResourceTypes,
+	)
 	if err != nil {
 		l.Error("wiz-connector: failed to read token response", zap.Error(err))
 		return nil, err

--- a/pkg/connector/resources.go
+++ b/pkg/connector/resources.go
@@ -55,8 +55,8 @@ func (o *resourceBuilder) Entitlements(ctx context.Context, resource *v2.Resourc
 	}
 	nodes := resourcePermissions.Data.EntityEffectiveAccessEntries.Nodes
 	for _, n := range nodes {
-		for _, at := range n.AccessTypes {
-			ent := o.resourceEntitlement(resource, at)
+		for _, p := range n.Permissions {
+			ent := o.resourceEntitlement(resource, p)
 			rv = append(rv, ent)
 		}
 	}
@@ -81,8 +81,8 @@ func (o *resourceBuilder) Grants(ctx context.Context, resource *v2.Resource, pTo
 			Resource:     n.GrantedEntity.Id,
 		}
 
-		for _, at := range n.AccessTypes {
-			rv = append(rv, sdkGrant.NewGrant(resource, at, principal))
+		for _, p := range n.Permissions {
+			rv = append(rv, sdkGrant.NewGrant(resource, p, principal))
 		}
 	}
 	return rv, nextPageToken, nil, nil

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -38,14 +38,17 @@ func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 
 		firstName, lastName := rs.SplitFullName(user.Name)
 		profile := map[string]interface{}{
-			"login":      primaryEmail,
-			"user_id":    user.Id,
-			"first_name": firstName,
-			"last_name":  lastName,
+			"login":       primaryEmail,
+			"user_id":     user.Id,
+			"first_name":  firstName,
+			"last_name":   lastName,
+			"external_id": user.Properties.ExternalId,
+			"native_type": user.Properties.NativeType,
 		}
 
 		userTraitOptions := []rs.UserTraitOption{
 			rs.WithEmail(primaryEmail, true),
+			rs.WithUserLogin(primaryEmail),
 			rs.WithUserProfile(profile),
 		}
 


### PR DESCRIPTION
#### Description
- take key, val for tags
- add resource type filter 
- use permissions instead of access types for entitlements/grants
- add external id/native type user properties 

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
