### PR TITLE
Use email for user id if present/add config to sync identities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       BATON_ENDPOINT_URL: 'https://api.us83.app.wiz.io/graphql'
       BATON_TAGS: ${{ secrets.BATON_TAGS }}
       CONNECTOR_ENTITLEMENT: 'wiz_query_resource_type:911d5b8b-1a17-5af0-b1b6-6cca33432c22:s3:*'
-      CONNECTOR_PRINCIPAL: 'd1ade4d7-e5c6-5754-9743-766a441d0c83'
+      CONNECTOR_PRINCIPAL: 'lauren.leach@conductorone.com'
     steps:
       - name: Install Go
         uses: actions/setup-go@v5

--- a/cmd/baton-wiz/config.go
+++ b/cmd/baton-wiz/config.go
@@ -13,7 +13,8 @@ var (
 	resourceIDs         = field.StringSliceField("resource-ids", field.WithDescription("The resource ids to sync"))
 	tags                = field.StringField("tags", field.WithDescription("The tags on resources to sync"))
 	resourceTypes       = field.StringSliceField("wiz-resource-types", field.WithDescription("The wiz resource-types to sync"))
-	configurationFields = []field.SchemaField{clientIDField, clientSecretField, endpointURL, authURL, audience, resourceIDs, tags, resourceTypes}
+	syncIdentities      = field.BoolField("sync-identities", field.WithDescription("Enable if wiz identities should be synced"))
+	configurationFields = []field.SchemaField{clientIDField, clientSecretField, endpointURL, authURL, audience, resourceIDs, tags, resourceTypes, syncIdentities}
 )
 
 var configRelations = []field.SchemaFieldRelationship{

--- a/cmd/baton-wiz/main.go
+++ b/cmd/baton-wiz/main.go
@@ -51,16 +51,18 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	resourceIDs := v.GetStringSlice(resourceIDs.FieldName)
 	resourceTags := v.GetString(tags.FieldName)
 	resourceTypes := v.GetStringSlice(resourceTypes.FieldName)
+	syncIdentities := v.GetBool(syncIdentities.FieldName)
 
 	cb, err := connector.New(ctx, &connector.Config{
-		ClientID:      clientID,
-		ClientSecret:  clientSecret,
-		EndpointURL:   endpointURL,
-		AuthURL:       authURL,
-		Audience:      audience,
-		ResourceIDs:   resourceIDs,
-		ResourceTags:  resourceTags,
-		ResourceTypes: resourceTypes,
+		ClientID:       clientID,
+		ClientSecret:   clientSecret,
+		EndpointURL:    endpointURL,
+		AuthURL:        authURL,
+		Audience:       audience,
+		ResourceIDs:    resourceIDs,
+		ResourceTags:   resourceTags,
+		ResourceTypes:  resourceTypes,
+		SyncIdentities: syncIdentities,
 	})
 	if err != nil {
 		l.Error("wiz-connector: error creating connector", zap.Error(err))

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -39,14 +39,10 @@ type GrantedEntity struct {
 	Name       string `json:"name"`
 	Type       string `json:"type"`
 	Properties struct {
-		VertexID     string `json:"_vertexID"`
 		Email        string `json:"email"`
 		Emails       Emails `json:"emails,omitempty"`
-		Name         string `json:"name"`
-		NativeType   string `json:"nativeType"`
 		PrimaryEmail string `json:"primaryEmail"`
 		Enabled      *bool  `json:"accountEnabled"`
-		ExternalId   string `json:"externalId"`
 	} `json:"properties"`
 }
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -18,14 +18,15 @@ import (
 var resourceTagErr = errors.New(`error parsing resource tags, format should be [{"key":"key1","val":"val1"}, {"key":"key2","val":"val2"}]`)
 
 type Config struct {
-	ClientID      string
-	ClientSecret  string
-	EndpointURL   string
-	AuthURL       string
-	Audience      string
-	ResourceIDs   []string
-	ResourceTags  string
-	ResourceTypes []string
+	ClientID       string
+	ClientSecret   string
+	EndpointURL    string
+	AuthURL        string
+	Audience       string
+	ResourceIDs    []string
+	ResourceTags   string
+	ResourceTypes  []string
+	SyncIdentities bool
 }
 
 type Connector struct {
@@ -92,6 +93,7 @@ func New(ctx context.Context, config *Config) (*Connector, error) {
 		config.ResourceIDs,
 		resourceTags,
 		config.ResourceTypes,
+		config.SyncIdentities,
 	)
 	if err != nil {
 		l.Error("wiz-connector: failed to read token response", zap.Error(err))

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -38,12 +38,10 @@ func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 
 		firstName, lastName := rs.SplitFullName(user.Name)
 		profile := map[string]interface{}{
-			"login":       primaryEmail,
-			"user_id":     user.Id,
-			"first_name":  firstName,
-			"last_name":   lastName,
-			"external_id": user.Properties.ExternalId,
-			"native_type": user.Properties.NativeType,
+			"login":      primaryEmail,
+			"user_id":    user.Id,
+			"first_name": firstName,
+			"last_name":  lastName,
 		}
 
 		userTraitOptions := []rs.UserTraitOption{
@@ -70,10 +68,15 @@ func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 			}
 		}
 
+		userId := primaryEmail
+		if userId == "" {
+			userId = user.Id
+		}
+
 		resource, err := rs.NewUserResource(
 			user.Name,
 			userResourceType,
-			user.Id,
+			userId,
 			userTraitOptions,
 		)
 		if err != nil {


### PR DESCRIPTION
#### Description
- Use email for user id if present to prevent duplicate users 
- Add config to sync identities 
- Split entitlement/grant queries up
- Remove unnecessary fields 
- Make resource id cache global (to avoid pushing duplicate resource ids in pagination bag when the resources are present in multiple pages) 

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
