### PR TITLE
Add schema field to enable syncing service accounts

### DIFF
--- a/cmd/baton-wiz/config.go
+++ b/cmd/baton-wiz/config.go
@@ -5,16 +5,18 @@ import (
 )
 
 var (
-	clientIDField       = field.StringField("wiz-client-id", field.WithRequired(true), field.WithDescription("The client ID used to authenticate with Wiz"))
-	clientSecretField   = field.StringField("wiz-client-secret", field.WithRequired(true), field.WithDescription("The client secret used to authenticate with Wiz"))
-	endpointURL         = field.StringField("endpoint-url", field.WithRequired(true), field.WithDescription("The endpoint url used to authenticate with Wiz"))
-	authURL             = field.StringField("auth-url", field.WithRequired(true), field.WithDescription("The auth url used to authenticate with Wiz"))
-	audience            = field.StringField("audience", field.WithDefaultValue("wiz-api"), field.WithDescription("The audience used to authenticate with Wiz"))
-	resourceIDs         = field.StringSliceField("resource-ids", field.WithDescription("The resource ids to sync"))
-	tags                = field.StringField("tags", field.WithDescription("The tags on resources to sync"))
-	resourceTypes       = field.StringSliceField("wiz-resource-types", field.WithDescription("The wiz resource-types to sync"))
-	syncIdentities      = field.BoolField("sync-identities", field.WithDescription("Enable if wiz identities should be synced"))
-	configurationFields = []field.SchemaField{clientIDField, clientSecretField, endpointURL, authURL, audience, resourceIDs, tags, resourceTypes, syncIdentities}
+	clientIDField     = field.StringField("wiz-client-id", field.WithRequired(true), field.WithDescription("The client ID used to authenticate with Wiz"))
+	clientSecretField = field.StringField("wiz-client-secret", field.WithRequired(true), field.WithDescription("The client secret used to authenticate with Wiz"))
+	endpointURL       = field.StringField("endpoint-url", field.WithRequired(true), field.WithDescription("The endpoint url used to authenticate with Wiz"))
+	authURL           = field.StringField("auth-url", field.WithRequired(true), field.WithDescription("The auth url used to authenticate with Wiz"))
+	audience          = field.StringField("audience", field.WithDefaultValue("wiz-api"), field.WithDescription("The audience used to authenticate with Wiz"))
+	resourceIDs       = field.StringSliceField("resource-ids", field.WithDescription("The resource ids to sync"))
+	tags              = field.StringField("tags", field.WithDescription("The tags on resources to sync"))
+	resourceTypes     = field.StringSliceField("wiz-resource-types", field.WithDescription("The wiz resource-types to sync"))
+	syncIdentities    = field.BoolField("sync-identities", field.WithDescription("Enable if wiz identities should be synced"))
+	syncServiceUsers  = field.BoolField("sync-service-accounts", field.WithDescription("Enable if wiz service accounts should be synced"))
+
+	configurationFields = []field.SchemaField{clientIDField, clientSecretField, endpointURL, authURL, audience, resourceIDs, tags, resourceTypes, syncIdentities, syncServiceUsers}
 )
 
 var configRelations = []field.SchemaFieldRelationship{

--- a/cmd/baton-wiz/main.go
+++ b/cmd/baton-wiz/main.go
@@ -52,17 +52,19 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	resourceTags := v.GetString(tags.FieldName)
 	resourceTypes := v.GetStringSlice(resourceTypes.FieldName)
 	syncIdentities := v.GetBool(syncIdentities.FieldName)
+	syncServiceUsers := v.GetBool(syncServiceUsers.FieldName)
 
 	cb, err := connector.New(ctx, &connector.Config{
-		ClientID:       clientID,
-		ClientSecret:   clientSecret,
-		EndpointURL:    endpointURL,
-		AuthURL:        authURL,
-		Audience:       audience,
-		ResourceIDs:    resourceIDs,
-		ResourceTags:   resourceTags,
-		ResourceTypes:  resourceTypes,
-		SyncIdentities: syncIdentities,
+		ClientID:            clientID,
+		ClientSecret:        clientSecret,
+		EndpointURL:         endpointURL,
+		AuthURL:             authURL,
+		Audience:            audience,
+		ResourceIDs:         resourceIDs,
+		ResourceTags:        resourceTags,
+		ResourceTypes:       resourceTypes,
+		SyncIdentities:      syncIdentities,
+		SyncServiceAccounts: syncServiceUsers,
 	})
 	if err != nil {
 		l.Error("wiz-connector: error creating connector", zap.Error(err))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -92,8 +92,7 @@ const GrantedEntityTypeIdentity = "IDENTITY"
 const GrantedEntityTypeUserAccount = "USER_ACCOUNT"
 const GrantedEntityTypeServiceAccount = "SERVICE_ACCOUNT"
 
-var grantedEntityTypeFilter = []string{GrantedEntityTypeUserAccount, GrantedEntityTypeServiceAccount}
-var grantedEntityTypeWithIdentityFilter = append(grantedEntityTypeFilter, GrantedEntityTypeIdentity)
+var grantedEntityTypeUserAccountFilter = []string{GrantedEntityTypeUserAccount}
 
 type UserTypeToken struct {
 	UserType string `json:"user_type"`
@@ -130,6 +129,7 @@ func New(
 	resourceTags []*ResourceTag,
 	resourceTypes []string,
 	syncIdentities bool,
+	syncServiceAccounts bool,
 ) (*Client, error) {
 	l := ctxzap.Extract(ctx)
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, l))
@@ -148,9 +148,12 @@ func New(
 		return nil, err
 	}
 
-	userTypeFilter := grantedEntityTypeFilter
+	userTypeFilter := grantedEntityTypeUserAccountFilter
+	if syncServiceAccounts {
+		userTypeFilter = append(userTypeFilter, GrantedEntityTypeServiceAccount)
+	}
 	if syncIdentities {
-		userTypeFilter = grantedEntityTypeWithIdentityFilter
+		userTypeFilter = append(userTypeFilter, GrantedEntityTypeIdentity)
 	}
 
 	client := Client{

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -18,15 +18,16 @@ import (
 var resourceTagErr = errors.New(`error parsing resource tags, format should be [{"key":"key1","val":"val1"}, {"key":"key2","val":"val2"}]`)
 
 type Config struct {
-	ClientID       string
-	ClientSecret   string
-	EndpointURL    string
-	AuthURL        string
-	Audience       string
-	ResourceIDs    []string
-	ResourceTags   string
-	ResourceTypes  []string
-	SyncIdentities bool
+	ClientID            string
+	ClientSecret        string
+	EndpointURL         string
+	AuthURL             string
+	Audience            string
+	ResourceIDs         []string
+	ResourceTags        string
+	ResourceTypes       []string
+	SyncIdentities      bool
+	SyncServiceAccounts bool
 }
 
 type Connector struct {
@@ -94,6 +95,7 @@ func New(ctx context.Context, config *Config) (*Connector, error) {
 		resourceTags,
 		config.ResourceTypes,
 		config.SyncIdentities,
+		config.SyncServiceAccounts,
 	)
 	if err != nil {
 		l.Error("wiz-connector: failed to read token response", zap.Error(err))


### PR DESCRIPTION
#### Description
- Add schema field to enable syncing service accounts


#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
