### PR TITLE
Add project id field

### DIFF
--- a/cmd/baton-wiz/config.go
+++ b/cmd/baton-wiz/config.go
@@ -5,19 +5,23 @@ import (
 )
 
 var (
-	clientIDField     = field.StringField("wiz-client-id", field.WithRequired(true), field.WithDescription("The client ID used to authenticate with Wiz"))
+	clientIDField = field.StringField("wiz-client-id", field.WithRequired(true), field.WithDescription("The client ID used to authenticate with Wiz"))
 	clientSecretField = field.StringField("wiz-client-secret", field.WithRequired(true), field.WithDescription("The client secret used to authenticate with Wiz"))
-	endpointURL       = field.StringField("endpoint-url", field.WithRequired(true), field.WithDescription("The endpoint url used to authenticate with Wiz"))
-	authURL           = field.StringField("auth-url", field.WithRequired(true), field.WithDescription("The auth url used to authenticate with Wiz"))
-	audience          = field.StringField("audience", field.WithDefaultValue("wiz-api"), field.WithDescription("The audience used to authenticate with Wiz"))
-	resourceIDs       = field.StringSliceField("resource-ids", field.WithDescription("The resource ids to sync"))
-	tags              = field.StringField("tags", field.WithDescription("The tags on resources to sync"))
-	resourceTypes     = field.StringSliceField("wiz-resource-types", field.WithDescription("The wiz resource-types to sync"))
-	syncIdentities    = field.BoolField("sync-identities", field.WithDescription("Enable if wiz identities should be synced"))
-	syncServiceUsers  = field.BoolField("sync-service-accounts", field.WithDescription("Enable if wiz service accounts should be synced"))
-	externalSyncMode  = field.BoolField("external-sync-mode", field.WithDescription("Enable external sync mode"))
+	endpointURL = field.StringField("endpoint-url", field.WithRequired(true), field.WithDescription("The endpoint url used to authenticate with Wiz"))
+	authURL = field.StringField("auth-url", field.WithRequired(true), field.WithDescription("The auth url used to authenticate with Wiz"))
+	audience = field.StringField("audience", field.WithDefaultValue("wiz-api"), field.WithDescription("The audience used to authenticate with Wiz"))
+	resourceIDs = field.StringSliceField("resource-ids", field.WithDescription("The resource ids to sync"))
+	tags = field.StringField("tags", field.WithDescription("The tags on resources to sync"))
+	resourceTypes = field.StringSliceField("wiz-resource-types", field.WithDescription("The wiz resource-types to sync"))
+	syncIdentities = field.BoolField("sync-identities", field.WithDescription("Enable if wiz identities should be synced"))
+	syncServiceUsers = field.BoolField("sync-service-accounts", field.WithDescription("Enable if wiz service accounts should be synced"))
+	externalSyncMode = field.BoolField("external-sync-mode", field.WithDescription("Enable external sync mode"))
+	projectID = field.StringField("project-id",
+		field.WithDescription("Scope the resource graph query to a specific project. Required if service account does not have access to all projects."))
 
-	configurationFields = []field.SchemaField{clientIDField, clientSecretField, endpointURL, authURL, audience, resourceIDs, tags, resourceTypes, syncIdentities, syncServiceUsers, externalSyncMode}
+	configurationFields = []field.SchemaField{
+		clientIDField, clientSecretField, endpointURL, authURL, audience, resourceIDs, tags, resourceTypes, syncIdentities, syncServiceUsers, externalSyncMode, projectID,
+	}
 )
 
 var configRelations = []field.SchemaFieldRelationship{

--- a/cmd/baton-wiz/config.go
+++ b/cmd/baton-wiz/config.go
@@ -5,18 +5,18 @@ import (
 )
 
 var (
-	clientIDField = field.StringField("wiz-client-id", field.WithRequired(true), field.WithDescription("The client ID used to authenticate with Wiz"))
+	clientIDField     = field.StringField("wiz-client-id", field.WithRequired(true), field.WithDescription("The client ID used to authenticate with Wiz"))
 	clientSecretField = field.StringField("wiz-client-secret", field.WithRequired(true), field.WithDescription("The client secret used to authenticate with Wiz"))
-	endpointURL = field.StringField("endpoint-url", field.WithRequired(true), field.WithDescription("The endpoint url used to authenticate with Wiz"))
-	authURL = field.StringField("auth-url", field.WithRequired(true), field.WithDescription("The auth url used to authenticate with Wiz"))
-	audience = field.StringField("audience", field.WithDefaultValue("wiz-api"), field.WithDescription("The audience used to authenticate with Wiz"))
-	resourceIDs = field.StringSliceField("resource-ids", field.WithDescription("The resource ids to sync"))
-	tags = field.StringField("tags", field.WithDescription("The tags on resources to sync"))
-	resourceTypes = field.StringSliceField("wiz-resource-types", field.WithDescription("The wiz resource-types to sync"))
-	syncIdentities = field.BoolField("sync-identities", field.WithDescription("Enable if wiz identities should be synced"))
-	syncServiceUsers = field.BoolField("sync-service-accounts", field.WithDescription("Enable if wiz service accounts should be synced"))
-	externalSyncMode = field.BoolField("external-sync-mode", field.WithDescription("Enable external sync mode"))
-	projectID = field.StringField("project-id",
+	endpointURL       = field.StringField("endpoint-url", field.WithRequired(true), field.WithDescription("The endpoint url used to authenticate with Wiz"))
+	authURL           = field.StringField("auth-url", field.WithRequired(true), field.WithDescription("The auth url used to authenticate with Wiz"))
+	audience          = field.StringField("audience", field.WithDefaultValue("wiz-api"), field.WithDescription("The audience used to authenticate with Wiz"))
+	resourceIDs       = field.StringSliceField("resource-ids", field.WithDescription("The resource ids to sync"))
+	tags              = field.StringField("tags", field.WithDescription("The tags on resources to sync"))
+	resourceTypes     = field.StringSliceField("wiz-resource-types", field.WithDescription("The wiz resource-types to sync"))
+	syncIdentities    = field.BoolField("sync-identities", field.WithDescription("Enable if wiz identities should be synced"))
+	syncServiceUsers  = field.BoolField("sync-service-accounts", field.WithDescription("Enable if wiz service accounts should be synced"))
+	externalSyncMode  = field.BoolField("external-sync-mode", field.WithDescription("Enable external sync mode"))
+	projectID         = field.StringField("project-id",
 		field.WithDescription("Scope the resource graph query to a specific project. Required if service account does not have access to all projects."))
 
 	configurationFields = []field.SchemaField{

--- a/cmd/baton-wiz/main.go
+++ b/cmd/baton-wiz/main.go
@@ -54,6 +54,7 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	syncIdentities := v.GetBool(syncIdentities.FieldName)
 	syncServiceUsers := v.GetBool(syncServiceUsers.FieldName)
 	externalSyncMode := v.GetBool(externalSyncMode.FieldName)
+	projectID := v.GetString(projectID.FieldName)
 
 	cb, err := connector.New(ctx, &connector.Config{
 		ClientID:            clientID,
@@ -67,6 +68,7 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 		SyncIdentities:      syncIdentities,
 		SyncServiceAccounts: syncServiceUsers,
 		ExternalSyncMode:    externalSyncMode,
+		ProjectID:           projectID,
 	})
 	if err != nil {
 		l.Error("wiz-connector: error creating connector", zap.Error(err))

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -29,6 +29,7 @@ type Config struct {
 	SyncIdentities      bool
 	SyncServiceAccounts bool
 	ExternalSyncMode    bool
+	ProjectID           string
 }
 
 type Connector struct {
@@ -101,7 +102,7 @@ func New(ctx context.Context, config *Config) (*Connector, error) {
 		config.SyncIdentities,
 		config.SyncServiceAccounts,
 		config.ExternalSyncMode,
-	)
+		config.ProjectID)
 	if err != nil {
 		l.Error("wiz-connector: failed to read token response", zap.Error(err))
 		return nil, err


### PR DESCRIPTION
#### Description

- [x] Bug fix
- [ ] New feature

Add project id field to scope the graph query to a specific project

If the service account has limited access to certain projects, we need to provide that in the graph search query. Wiz requires a single project in the graph search query.

In the API explorer for the `projectId` on `graphSearch`:

> Scope the graph query to a specific project. Admins may specify '*'. But regular users must specify a single scope project id

Fixes [BB-384](https://conductorone.atlassian.net/browse/BB-384)


#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)


[BB-384]: https://conductorone.atlassian.net/browse/BB-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ